### PR TITLE
[16.0][FIX] OD-84, account_statement_import_online_ponto: don't retrieve partner

### DIFF
--- a/account_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
+++ b/account_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
@@ -161,11 +161,9 @@ class OnlineBankStatementProvider(models.Model):
         # For each period, create or update statement lines
         for period, statement_lines in grouped_periods.items():
             (date_since, date_until) = period
-            statement = self._create_or_update_statement(
+            self._create_or_update_statement(
                 (statement_lines, {}), date_since, date_until
             )
-            for line in statement.line_ids.filtered(lambda l: not l.partner_id):
-                line.partner_id = line._retrieve_partner()
 
     def _ponto_get_transaction_vals(self, transaction):
         """Translate information from Ponto to statement line vals."""


### PR DESCRIPTION
Fixes 'You cannot delete an item linked to a posted entry.' when assigning a partner on a statement that is already reconciled. Assigning partners at this stage is redundant anyway and leaving it to the reconciliation process will prevent some misreconciliations.

Zoals https://github.com/OCA/bank-statement-import/pull/ <prevent crosslinking to public PR> 648