### PR TITLE
[16.0][IMP] OD-84, account_statement_import_online: only update journal when online service is set

### DIFF
--- a/account_statement_import_online/models/account_journal.py
+++ b/account_statement_import_online/models/account_journal.py
@@ -77,7 +77,8 @@ class AccountJournal(models.Model):
     def write(self, vals):
         self._update_vals(vals)
         res = super().write(vals)
-        self._update_providers()
+        if vals.get("online_bank_statement_provider"):
+            self._update_providers()
         return res
 
     def _update_vals(self, vals):


### PR DESCRIPTION
This prevents a flood of logs in case your journals are written very often.

Zoals https://github.com/OCA/bank-statement-import/pull/<prevent crosslinking in public pr>668